### PR TITLE
Add support for Amazfit GTR 3 Pro Limited Edition

### DIFF
--- a/app.json
+++ b/app.json
@@ -267,6 +267,10 @@
           "deviceSource": 230
         },
         {
+          "name": "Madrid1",
+          "deviceSource": 242
+        },
+        {
           "name": "Madrid2",
           "deviceSource": 6095106
         }


### PR DESCRIPTION
Added another deviceSource to the amazfit-gtr-3-pro platforms to target the Amazfit GTR 3 Pro Limited Edition smartwatch. 